### PR TITLE
Update Hazelcast documentation link version

### DIFF
--- a/In Memory Computing Essentials/README.md
+++ b/In Memory Computing Essentials/README.md
@@ -4,6 +4,6 @@
 
 Determine whether you will use Hazelcast installed locally on your computer or Hazelcast Cloud. 
 
-For local installation, go to the [Hazelcast Platform Documentation](https://docs.hazelcast.com/hazelcast/5.0/). Follow the instructions to install Hazelcast and connect a Java client. (Java is required for this course.) 
+For local installation, go to the [Hazelcast Platform Documentation](https://docs.hazelcast.com/hazelcast/latest/). Follow the instructions to install Hazelcast and connect a Java client. (Java is required for this course.) 
 
 For Hazelcast Cloud, go to the [Hazelcast Cloud Documentation](https://docs.hazelcast.com/cloud/getting-started) and follow the instructions to set up a free instance of Hazelcast, then connect a Java client.

--- a/In_Memory_Computing_Essentials/README.md
+++ b/In_Memory_Computing_Essentials/README.md
@@ -4,7 +4,7 @@
 
 Determine whether you will use Hazelcast installed locally on your computer or Hazelcast Cloud. 
 
-For local installation, go to the [Hazelcast Platform Documentation](https://docs.hazelcast.com/hazelcast/5.0/). Follow the instructions to install Hazelcast and connect a Java client. (Java is required for this course.) 
+For local installation, go to the [Hazelcast Platform Documentation](https://docs.hazelcast.com/hazelcast/latest/). Follow the instructions to install Hazelcast and connect a Java client. (Java is required for this course.) 
 
 For Hazelcast Cloud, go to the [Hazelcast Cloud Documentation](https://docs.hazelcast.com/cloud/getting-started) and follow the instructions to set up a free instance of Hazelcast, then connect a Java client.
 

--- a/In_Memory_Storage_Essentials/README.md
+++ b/In_Memory_Storage_Essentials/README.md
@@ -9,7 +9,7 @@
 
 Determine whether you will use Hazelcast installed locally on your computer or Hazelcast Cloud. 
 
-For local installation, go to the [Hazelcast Platform Documentation](https://docs.hazelcast.com/hazelcast/5.0/). Follow the instructions to install Hazelcast, install Management Center, and connect a Java client. Before you start the cluster, add the following to your hazelcast.xml configuration:
+For local installation, go to the [Hazelcast Platform Documentation](https://docs.hazelcast.com/hazelcast/latest/). Follow the instructions to install Hazelcast, install Management Center, and connect a Java client. Before you start the cluster, add the following to your hazelcast.xml configuration:
 ```
     <map name="training-eviction">
         <eviction eviction-policy="LFU" max-size-policy="USED_HEAP_SIZE" size="1"/>


### PR DESCRIPTION
Replace any references to `https://docs.hazelcast.com/hazelcast/5.x` with `https://docs.hazelcast.com/hazelcast/latest`